### PR TITLE
Ensure AlexaRequest is processed before accessing slots

### DIFF
--- a/src/Request/AlexaRequest.php
+++ b/src/Request/AlexaRequest.php
@@ -7,7 +7,7 @@ class AlexaRequest extends Request implements \Develpr\AlexaApp\Contracts\AlexaR
 	private $data = null;
 	private $processed = false;
 	private $intent = null;
-	private $slots = null;
+	private $slots = [];
 	private $promptResponse = null;
 
 	protected function getData()
@@ -112,6 +112,9 @@ class AlexaRequest extends Request implements \Develpr\AlexaApp\Contracts\AlexaR
 	 */
 	public function slot($slotKey)
 	{
+		if( ! $this->processed )
+			$this->process();
+
 		$key_exists = (array_key_exists($slotKey, $this->slots));
 
 		if (!$key_exists) {
@@ -126,6 +129,9 @@ class AlexaRequest extends Request implements \Develpr\AlexaApp\Contracts\AlexaR
 	 */
 	public function slots()
 	{
+		if( ! $this->processed )
+			$this->process();
+
 		return $this->slots;
 	}
 
@@ -143,7 +149,7 @@ class AlexaRequest extends Request implements \Develpr\AlexaApp\Contracts\AlexaR
 		$data = $this->getContent();
 		$this->data = json_decode($data, true);
 		$this->intent = array_get($this->data, 'request.intent.name');
-		$this->slots = array_get($this->data, 'request.intent.slots');
+		$this->slots = array_get($this->data, 'request.intent.slots', []);
 
 		if(!$this->slots)
 			$this->slots = [];


### PR DESCRIPTION
Without this fix, attempting to access a slot can cause the following exception to be thrown:

```
'ErrorException' with message 'array_key_exists() expects parameter 2 to be array, null given' in vendor/develpr/alexa-app/src/Request/AlexaRequest.php:115
```

A temporary workaround is to call any of the other getters (like `getIntent()`) beforehand to ensure the request is processed and `$this->slots` is populated.