### PR TITLE
Have the other setters return the current object

### DIFF
--- a/src/Response/Card.php
+++ b/src/Response/Card.php
@@ -63,6 +63,8 @@ class Card implements Arrayable
     public function setContent($content)
     {
         $this->content = $content;
+
+        return $this;
     }
 
     /**
@@ -71,6 +73,8 @@ class Card implements Arrayable
     public function setSubtitle($subtitle)
     {
         $this->subtitle = $subtitle;
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
`setType()` and `setTitle()` were returning `$this`, but these two setters were not.  I've therefore ensured all setters `return $this` for consistency.