### PR TITLE
Allow playback of audio from HTTP sources

### DIFF
--- a/config/alexa.php
+++ b/config/alexa.php
@@ -228,4 +228,29 @@ return [
 
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | audio
+    |--------------------------------------------------------------------------
+    |
+    | Configuration related to playing audio
+    |
+    */
+    'audio' => [
+        /*
+        |--------------------------------------------------------------------------
+        | proxy
+        |--------------------------------------------------------------------------
+        |
+        | Amazon doesn't accept HTTP audio files. If you set a proxy, all audio
+        | files are routed via a proxy which encapsulates the audio file in a m3u
+        | playlist that can be served via HTTPS.
+        |
+        */
+        'proxy' => [
+            'enabled' => env('ALEXA_AUDIO_PROXY_ENABLED', 'false'),
+            'route' => env('ALEXA_AUDIO_PROXY_ROUTE', '/alexa/audio/proxy')
+        ]
+    ]
+
 ];

--- a/src/Alexa.php
+++ b/src/Alexa.php
@@ -141,6 +141,11 @@ class Alexa
      */
     public function play($url, $token = null, $offsetInMilliseconds = null, $playBehavior = null, $expectedPreviousToken = null)
     {
+        if($this->app['config']['alexa.audio.proxy.enabled'])
+        {
+            $url = url($this->app['config']['alexa.audio.proxy.route'] . '/' . urlencode($url));
+        }
+        
         $audio = new Play($url, $token, $offsetInMilliseconds, $playBehavior, $expectedPreviousToken);
 
         $response = new AlexaResponse();
@@ -175,7 +180,7 @@ class Alexa
         $token = $this->context('AudioPlayer.token');
         $url = cache($token);
         $offset = $this->context('AudioPlayer.offsetInMilliseconds');
-        return $this->play($url, $token, $offset); 
+        return $this->play($url, $token, $offset);
     }
 
     /**

--- a/src/Alexa.php
+++ b/src/Alexa.php
@@ -141,9 +141,9 @@ class Alexa
      */
     public function play($url, $token = null, $offsetInMilliseconds = null, $playBehavior = null, $expectedPreviousToken = null)
     {
-        if($this->app['config']['alexa.audio.proxy.enabled'])
+        if(config('alexa.audio.proxy.enabled'))
         {
-            $url = url($this->app['config']['alexa.audio.proxy.route'] . '/' . urlencode($url));
+            $url = url(config('alexa.audio.proxy.route') . '/' . base64_encode($url));
         }
         
         $audio = new Play($url, $token, $offsetInMilliseconds, $playBehavior, $expectedPreviousToken);

--- a/src/Provider/LaravelServiceProvider.php
+++ b/src/Provider/LaravelServiceProvider.php
@@ -5,18 +5,27 @@ namespace Develpr\AlexaApp\Provider;
 use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Support\ServiceProvider;
 use ReflectionClass;
+use Route;
 
 class LaravelServiceProvider extends ServiceProvider
 {
     public function boot()
     {
         $this->publishes([
-            realpath(__DIR__.'/../../config/alexa.php') => config_path('alexa.php'),
+            realpath(__DIR__ . '/../../config/alexa.php') => config_path('alexa.php'),
         ], 'config');
 
         $this->publishes([
-            realpath(__DIR__.'/../../database/2015_06_21_000000_create_alexa_devices_table.php') => database_path('/migrations/2015_06_21_000000_create_alexa_devices_table.php'),
+            realpath(__DIR__ . '/../../database/2015_06_21_000000_create_alexa_devices_table.php') => database_path('/migrations/2015_06_21_000000_create_alexa_devices_table.php'),
         ], 'migrations');
+
+        if ($this->app['config']['alexa.audio.proxy.enabled'])
+        {
+            Route::get($this->app['config']['alexa.audio.proxy.route'], function($audiofile) {
+                return response(url_decode($audiofile))
+                    ->header('Content-Type', 'application/x-mpegurl');
+            });
+        }
     }
 
     /**

--- a/src/Provider/LaravelServiceProvider.php
+++ b/src/Provider/LaravelServiceProvider.php
@@ -21,8 +21,8 @@ class LaravelServiceProvider extends ServiceProvider
 
         if ($this->app['config']['alexa.audio.proxy.enabled'])
         {
-            Route::get($this->app['config']['alexa.audio.proxy.route'], function($audiofile) {
-                return response(url_decode($audiofile))
+            Route::get($this->app['config']['alexa.audio.proxy.route'] . '/{audiofile}', function($audiofile) {
+                return response(base64_decode($audiofile))
                     ->header('Content-Type', 'application/x-mpegurl');
             });
         }


### PR DESCRIPTION
Amazon doesn't accept links to HTTP audio files for playback. With this PR you can set a proxy and all audio files are routed via this proxy which encapsulates the audio file in a pseudo m3u playlist that then can be served via HTTPS.