### PR TITLE
Correct class import alias to prevent conflicts

### DIFF
--- a/src/Response/AlexaResponse.php
+++ b/src/Response/AlexaResponse.php
@@ -2,7 +2,7 @@
 
 namespace Develpr\AlexaApp\Response;
 
-use Develpr\AlexaApp\Contracts\OutputSpeech as Speech;
+use Develpr\AlexaApp\Contracts\OutputSpeech as OutSpeech;
 use Develpr\AlexaApp\Response\Directives\AudioPlayer\Play;
 use Develpr\AlexaApp\Response\Directives\Directive;
 use Illuminate\Contracts\Support\Jsonable;
@@ -70,11 +70,11 @@ class AlexaResponse implements Jsonable
     private $promptResponseIntent = null;
 
     /**
-     * @param Speech|null   $speech
+     * @param OutSpeech|null   $speech
      * @param Card|null     $card
      * @param Reprompt|null $reprompt
      */
-    public function __construct(Speech $speech = null, Card $card = null, Reprompt $reprompt = null)
+    public function __construct(OutSpeech $speech = null, Card $card = null, Reprompt $reprompt = null)
     {
         $this->speech = $speech;
         $this->card = $card;
@@ -130,7 +130,7 @@ class AlexaResponse implements Jsonable
 
         //Check to see if a speech, card, or reprompt object are set and if so
         //add them to the data object
-        if (!is_null($this->speech) && $this->speech instanceof Speech) {
+        if (!is_null($this->speech) && $this->speech instanceof OutSpeech) {
             $response['outputSpeech'] = $this->speech->toArray();
         }
 
@@ -189,11 +189,11 @@ class AlexaResponse implements Jsonable
     }
 
     /**
-     * @param Speech $speech
+     * @param OutSpeech $speech
      *
      * @return $this
      */
-    public function withSpeech(Speech $speech)
+    public function withSpeech(OutSpeech $speech)
     {
         return $this->setSpeech($speech);
     }
@@ -273,11 +273,11 @@ class AlexaResponse implements Jsonable
     }
 
     /**
-     * @param Speech $speech
+     * @param OutSpeech $speech
      *
      * @return $this
      */
-    public function setSpeech(Speech $speech)
+    public function setSpeech(OutSpeech $speech)
     {
         $this->speech = $speech;
 


### PR DESCRIPTION
I encountered a problem multiple times where the Speech class had already been imported.

I keep overwriting this file when i import the package in new apps. Thought i'd open a pr just to use a different alias on this class. 