### PR TITLE
Strong typisation check error if timestampTolerance is configured via .env file.

### DIFF
--- a/src/Http/Middleware/Certificate.php
+++ b/src/Http/Middleware/Certificate.php
@@ -163,7 +163,7 @@ class Certificate
     private function checkTimestampTolerance()
     {
         //If the timestamp tolerance is set to 0 we'll skip the check (see config)
-        if (array_get($this->config, 'timestampTolerance') === 0) {
+        if (intval(array_get($this->config, 'timestampTolerance')) === 0) {
             return;
         }
 


### PR DESCRIPTION
Strong typisation check error if timestampTolerance is configured via .env file.