### PR TITLE
Update Reprompt::toArray() to return array in correct format.

### DIFF
--- a/src/Response/Reprompt.php
+++ b/src/Response/Reprompt.php
@@ -4,4 +4,20 @@ namespace Develpr\AlexaApp\Response;
 
 class Reprompt extends Speech
 {
+    /**
+     * Get the instance as an array.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        $textKey = ($this->getType() === 'SSML') ? 'ssml' : 'text';
+
+        return [
+            'outputSpeech' => [
+                'type' => $this->getType(),
+                $textKey => $this->getValue(),
+            ],
+        ];
+    }
 }


### PR DESCRIPTION
I've updated the Reprompt class to return the response in the format Alexa is expecting. I guess they've changed the expected format of the response json because reprompts aren't working in their current form.