### PR TITLE
Base64 url for audio proxy routes

### DIFF
--- a/src/Alexa.php
+++ b/src/Alexa.php
@@ -158,7 +158,7 @@ class Alexa
     {
         if(config('alexa.audio.proxy.enabled'))
         {
-            $url = url(config('alexa.audio.proxy.route') . '/' . base64_encode($url));
+            $url = url(config('alexa.audio.proxy.route') . '/' . str_replace(['+', '/'], ['-', '_'], base64_encode($url)));
         }
         
         $audio = new Play($url, $token, $offsetInMilliseconds, $playBehavior, $expectedPreviousToken);

--- a/src/Provider/LaravelServiceProvider.php
+++ b/src/Provider/LaravelServiceProvider.php
@@ -22,7 +22,7 @@ class LaravelServiceProvider extends ServiceProvider
         if ($this->app['config']['alexa.audio.proxy.enabled'])
         {
             Route::get($this->app['config']['alexa.audio.proxy.route'] . '/{audiofile}', function($audiofile) {
-                return response(base64_decode($audiofile))
+                return response(base64_decode(str_replace(['-', '_'], ['+', '/'], $audiofile)))
                     ->header('Content-Type', 'application/x-mpegurl');
             });
         }


### PR DESCRIPTION
base64 encoded strings can contain "/" which messes up the route. This pull request replaces the signs that should not be used in an URL.
See: https://stackoverflow.com/a/11449627