### PR TITLE
Fix audio proxy non disabled by default cause typo

### DIFF
--- a/config/alexa.php
+++ b/config/alexa.php
@@ -248,7 +248,7 @@ return [
         |
         */
         'proxy' => [
-            'enabled' => env('ALEXA_AUDIO_PROXY_ENABLED', 'false'),
+            'enabled' => env('ALEXA_AUDIO_PROXY_ENABLED', false),
             'route' => env('ALEXA_AUDIO_PROXY_ROUTE', '/alexa/audio/proxy')
         ]
     ]


### PR DESCRIPTION
The proxy is enabled by default, as the default value passed to env() is declared in string format and not Boolean.

Corrected.